### PR TITLE
fix(deps): rust toolchain 2023-12-06; cargo-workspaces 0.2.44

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2.0.0
         with:
           crate: cargo-workspaces
+          version: v0.2.44
 
       - name: Setup marine
         uses: fluencelabs/setup-marine@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2.0.0
         with:
           crate: cargo-workspaces
-          version: v0.2.37
 
       - name: Setup marine
         uses: fluencelabs/setup-marine@v1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-08-27"
+channel = "nightly-2023-12-06"
 targets = [ "x86_64-unknown-linux-gnu", "wasm32-wasi", "x86_64-apple-darwin" ]
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Older one fails to build